### PR TITLE
fix: readd missing return statement after PR #29

### DIFF
--- a/src/headingWidget.ts
+++ b/src/headingWidget.ts
@@ -63,6 +63,7 @@ export function headingMarkerPlugin(showBeforeLineNumbers: boolean) {
         // Don't render if Live Preview is disabled
         if (!update.state.field(editorLivePreviewField)) {
           this.markers = RangeSet.empty;
+          return;
         }
 
         // Rebulid only when the document or the viewport was changed.


### PR DESCRIPTION
I have noticed that I removed return statement after [previous PR](#29), which made the heading markers always visible in the source mode. So, I put it back in order to work properly. Sorry for my unawareness.