### PR TITLE
feat: Migrate settings to Obsidian 1.13 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-obsidianmd": "0.2.9",
     "globals": "14.0.0",
     "jiti": "2.6.1",
-    "obsidian": "latest",
+    "obsidian": "^1.13.0",
     "commit-and-tag-version": "^12.7.3",
     "tslib": "2.5.0",
     "typescript": "5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 9.30.1(jiti@2.6.1)
       eslint-plugin-obsidianmd:
         specifier: 0.2.9
-        version: 0.2.9(@eslint/js@9.30.1)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))(eslint@9.30.1(jiti@2.6.1))(obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))
+        version: 0.2.9(@eslint/js@9.30.1)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))(eslint@9.30.1(jiti@2.6.1))(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))
       globals:
         specifier: 14.0.0
         version: 14.0.0
@@ -42,8 +42,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       obsidian:
-        specifier: latest
-        version: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+        specifier: ^1.13.0
+        version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -1570,8 +1570,8 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obsidian@1.12.3:
-    resolution: {integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==}
+  obsidian@1.13.1:
+    resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
     peerDependencies:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6
@@ -3180,7 +3180,7 @@ snapshots:
     dependencies:
       eslint: 9.30.1(jiti@2.6.1)
 
-  eslint-plugin-obsidianmd@0.2.9(@eslint/js@9.30.1)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))(eslint@9.30.1(jiti@2.6.1))(obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3)):
+  eslint-plugin-obsidianmd@0.2.9(@eslint/js@9.30.1)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3))(eslint@9.30.1(jiti@2.6.1))(obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3)):
     dependencies:
       '@eslint/config-helpers': 0.4.2
       '@eslint/js': 9.30.1
@@ -3197,7 +3197,7 @@ snapshots:
       eslint-plugin-no-unsanitized: 4.1.5(eslint@9.30.1(jiti@2.6.1))
       eslint-plugin-security: 2.1.1
       globals: 14.0.0
-      obsidian: 1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
+      obsidian: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       semver: 7.7.4
       typescript: 5.4.5
       typescript-eslint: 8.35.1(eslint@9.30.1(jiti@2.6.1))(typescript@5.6.3)
@@ -3910,7 +3910,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
+  obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,10 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import {
+  App,
+  PluginSettingTab,
+  Setting,
+  requireApiVersion,
+  type SettingDefinitionItem,
+} from "obsidian";
 import LapelPlugin from "./index";
 
 export interface LapelSettings {
@@ -17,6 +23,51 @@ export class LapelSettingsTab extends PluginSettingTab {
   constructor(app: App, plugin: LapelPlugin) {
     super(app, plugin);
     this.plugin = plugin;
+  }
+
+  getSettingDefinitions(): SettingDefinitionItem[] {
+    if (!requireApiVersion("1.13.0")) {
+      return [];
+    }
+
+    return [
+      {
+        name: "Show before line numbers",
+        desc: "Toggle whether the heading markers are shown before or after the line numbers in the gutter.",
+        control: {
+          type: "toggle",
+          key: "showBeforeLineNumbers",
+          defaultValue: DEFAULT_SETTINGS.showBeforeLineNumbers,
+        },
+      },
+      {
+        name: "Show in source mode",
+        desc: "Toggle whether the heading markers are shown in in source mode.",
+        control: {
+          type: "toggle",
+          key: "showInSourceMode",
+          defaultValue: DEFAULT_SETTINGS.showInSourceMode,
+        },
+      },
+    ];
+  }
+
+  async setControlValue(key: string, value: unknown): Promise<void> {
+    if (key === "showBeforeLineNumbers") {
+      await this.plugin.updateSettings(() => ({
+        showBeforeLineNumbers: value as boolean,
+      }));
+      return;
+    }
+
+    if (key === "showInSourceMode") {
+      await this.plugin.updateSettings(() => ({
+        showInSourceMode: value as boolean,
+      }));
+      return;
+    }
+
+    throw new Error(`Unknown Lapel setting key: ${key}`);
   }
 
   display(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,40 +34,32 @@ export class LapelSettingsTab extends PluginSettingTab {
       {
         name: "Show before line numbers",
         desc: "Toggle whether the heading markers are shown before or after the line numbers in the gutter.",
-        control: {
-          type: "toggle",
-          key: "showBeforeLineNumbers",
-          defaultValue: DEFAULT_SETTINGS.showBeforeLineNumbers,
-        },
+        render: (setting) =>
+          setting.addToggle((toggle) =>
+            toggle
+              .setValue(this.plugin.settings.showBeforeLineNumbers)
+              .onChange(async (value) => {
+                await this.plugin.updateSettings(() => ({
+                  showBeforeLineNumbers: value,
+                }));
+              })
+          ),
       },
       {
         name: "Show in source mode",
         desc: "Toggle whether the heading markers are shown in in source mode.",
-        control: {
-          type: "toggle",
-          key: "showInSourceMode",
-          defaultValue: DEFAULT_SETTINGS.showInSourceMode,
-        },
+        render: (setting) =>
+          setting.addToggle((toggle) =>
+            toggle
+              .setValue(this.plugin.settings.showInSourceMode)
+              .onChange(async (value) => {
+                await this.plugin.updateSettings(() => ({
+                  showInSourceMode: value,
+                }));
+              })
+          ),
       },
     ];
-  }
-
-  async setControlValue(key: string, value: unknown): Promise<void> {
-    if (key === "showBeforeLineNumbers") {
-      await this.plugin.updateSettings(() => ({
-        showBeforeLineNumbers: value as boolean,
-      }));
-      return;
-    }
-
-    if (key === "showInSourceMode") {
-      await this.plugin.updateSettings(() => ({
-        showInSourceMode: value as boolean,
-      }));
-      return;
-    }
-
-    throw new Error(`Unknown Lapel setting key: ${key}`);
   }
 
   display(): void {


### PR DESCRIPTION
Updates Lapel's settings tab to use Obsidian 1.13's declarative settings API while retaining the existing `display()` path for earlier Obsidian versions.

The declarative toggles save through the existing `updateSettings()` path, so changed settings still rebuild the heading-marker extension and refresh workspace options. The Obsidian development dependency is pinned to `^1.13.0` for the new API types.

Validation:

- [x] `pnpm run build` (passes, including ESLint and production esbuild)
- [x] Manual smoke test in Obsidian